### PR TITLE
Refactor player to use fewer threads

### DIFF
--- a/examples/slow/main.rs
+++ b/examples/slow/main.rs
@@ -10,9 +10,9 @@ fn main() {
         Tone::B.oct(2)  * 128,
         Tone::E.oct(2)  * 128,
         Tone::D.oct(2)  * 128,
-        Tone::C.oct(1)  * 128,
-        Tone::E.oct(1)  * 128,
-        Tone::B.oct(1)  * 128,
+        Tone::C.oct(2)  * 128,
+        Tone::E.oct(2)  * 128,
+        Tone::B.oct(2)  * 128,
         Tone::C.oct(2)  * 128,
     ]).transpose_down(Interval::Min2);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ impl Bpm {
 }
 
 pub trait Midibox: Send + Sync {
-    fn iter(&self) -> Box<dyn Iterator<Item=Vec<Midi>> + '_>;
+    fn render(&self) -> Vec<Vec<Midi>>;
 }
 
 

--- a/src/sequences.rs
+++ b/src/sequences.rs
@@ -169,13 +169,16 @@ impl Add<Interval> for FixedSequence {
 }
 
 impl Midibox for FixedSequence {
-    fn iter(&self) -> Box<dyn Iterator<Item=Vec<Midi>> + '_> {
-        return Box::new(
+    fn render(&self) -> Vec<Vec<Midi>> {
+        let size = self.notes.len();
+        return
             self.notes
                 .iter()
                 .map(|m| vec![*m])
                 .cycle()
-                .skip(self.head_position));
+                .skip(self.head_position)
+                .take(size)
+                .collect::<Vec<Vec<Midi>>>()
     }
 }
 


### PR DESCRIPTION
The previous form factor used N producer threads for N sequences. However the synchronization wasn't straightforward and there's really no reason to use so many threads. So to simplify, we just render each Midibox to a finite reel of notes to play and then keep track of the playheads for each channel inside of the player.