### PR TITLE
fix: failure in build script if output dir does not exist

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,14 @@
 use std::env;
+use std::fs::create_dir_all;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let original_out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
+    // create output directory if doesn't exist
     let out_dir = "./src/generated";
+    create_dir_all(out_dir)?;
+
     tonic_build::configure()
         .build_server(true)
         .out_dir(out_dir)


### PR DESCRIPTION
create dir if doesn't exist